### PR TITLE
Set Workspace and Store Directory

### DIFF
--- a/bin/stm-cd
+++ b/bin/stm-cd
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if alias argument is provided
+if [ -z "$1" ]; then
+    echo "Usage: stm-cd <store-alias>"
+    exit 1
+fi
+
+# Get directory from stm cd command
+dir=$(stm cd "$1")
+
+# Check if stm cd command succeeded
+if [ $? -eq 0 ]; then
+    cd "$dir"
+else
+    # Error message already printed by stm cd
+    exit 1
+fi 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "CLI tool to manage Shopify themes",
   "main": "dist/index.js",
   "bin": {
-    "stm": "./dist/index.js"
+    "stm": "./dist/index.js",
+    "stm-cd": "./bin/stm-cd"
   },
   "files": [
-    "README.md"
+    "README.md",
+    "bin/stm-cd"
   ],
   "keywords": [
     "shopify",

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,30 @@ Install the package globally:
   npm install -g shopify-theme-manager
 ```
 
-## Usage
+## Commands
 
-To use the tool, run the following command:
+### Add Store (`stm add`)
+
+Add a new Shopify store configuration. The command will prompt for:
+
+- Store ID (required)
+- Store alias (optional,defaults to store ID)
+- Project directory path (required)
 
 ```bash
-  stm
+stm add
+```
+
+### Set Workspace (`stm set-workspace`)
+
+Set the workspace directory for all projects. This is the root directory where all store projects are located.
+
+```bash
+# Set to specific directory
+stm set-workspace /path/to/workspace
+
+# Set to current directory
+stm set-workspace
 ```
 
 ### List Themes (`stm list`)
@@ -35,15 +53,23 @@ To use the tool, run the following command:
 List all themes for a specific store.
 
 ```bash
-  stm list <alias>
+stm list <store-alias> [--name <theme-name>]
 ```
 
-### Dev Theme (`stm dev`)
+### Development Server (`stm dev`)
 
-Start theme development server.
+Start theme development server for a specific theme.
 
 ```bash
-  stm dev <themeId>
+stm dev <theme-id>
+```
+
+### Change Directory (`stm cd`)
+
+Change to a store's project directory within the workspace.
+
+```bash
+stm-cd store-alias
 ```
 
 ## Configuration
@@ -54,28 +80,11 @@ The tool stores configurations in:
 ~/.config/shopify-theme-manager/config.json
 ```
 
-## Development
+Configuration includes:
 
-To contribute to this project:
+- Workspace directory
+- Store configurations (ID, alias, project directory)
 
-1. Clone the repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Run tests:
-   ```bash
-   npm test
-   ```
-4. Start in development mode:
-   ```bash
-   npm start
-   ```
+```
 
-## License
-
-ISC
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
+```

--- a/readme.md
+++ b/readme.md
@@ -24,18 +24,6 @@ Install the package globally:
 
 ## Commands
 
-### Add Store (`stm add`)
-
-Add a new Shopify store configuration. The command will prompt for:
-
-- Store ID (required)
-- Store alias (optional,defaults to store ID)
-- Project directory path (required)
-
-```bash
-stm add
-```
-
 ### Set Workspace (`stm set-workspace`)
 
 Set the workspace directory for all projects. This is the root directory where all store projects are located.
@@ -46,6 +34,18 @@ stm set-workspace /path/to/workspace
 
 # Set to current directory
 stm set-workspace
+```
+
+### Add Store (`stm add`)
+
+Add a new Shopify store configuration. The command will prompt for:
+
+- Store ID (required) - Your Shopify store ID (e.g., my-store.myshopify.com)
+- Store alias (optional, defaults to store ID) - A shorthand name for the store
+- Project directory path (required) - The directory containing your theme files
+
+```bash
+stm add
 ```
 
 ### List Themes (`stm list`)
@@ -69,7 +69,7 @@ stm dev <theme-id>
 Change to a store's project directory within the workspace.
 
 ```bash
-stm-cd store-alias
+stm cd store-alias
 ```
 
 ## Configuration
@@ -82,8 +82,45 @@ The tool stores configurations in:
 
 Configuration includes:
 
-- Workspace directory
-- Store configurations (ID, alias, project directory)
+- Workspace directory - Root directory for all projects
+- Store configurations:
+  - Store ID - Shopify store identifier
+  - Alias - Custom name for the store
+  - Project directory - Path to theme files (relative to workspace)
+
+## Example Workflow
+
+1. Set up workspace:
+
+   ```bash
+   stm set-workspace ~/shopify-projects
+   ```
+
+2. Add a store:
+
+   ```bash
+   stm add
+   # > Enter store ID: my-store.myshopify.com
+   # > Enter alias: store1
+   # > Enter project directory: store1-theme
+   ```
+
+3. Navigate to store directory:
+
+   ```bash
+   stm cd store1
+   ```
+
+4. List themes:
+
+   ```bash
+   stm list store1
+   ```
+
+5. Start development:
+   ```bash
+   stm dev <theme-id>
+   ```
 
 ```
 

--- a/src/__tests__/commands/project.test.ts
+++ b/src/__tests__/commands/project.test.ts
@@ -41,11 +41,12 @@ describe('Project Commands', () => {
   });
 
   describe('add command', () => {
-    it('should prompt for store details and add store configuration', async () => {
+    it('should prompt for store details and project directory', async () => {
       // Setup
       const mockAnswers = {
         storeId: 'test-store',
-        alias: 'test-alias'
+        alias: 'test-alias',
+        projectDirectory: '/path/to/project'
       };
       
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -65,12 +66,19 @@ describe('Project Commands', () => {
           type: 'input',
           name: 'alias',
           message: 'Enter an alias for the store (optional):'
+        }),
+        expect.objectContaining({
+          type: 'input',
+          name: 'projectDirectory',
+          message: 'Enter the project directory path:',
+          default: process.cwd()
         })
       ]);
       
       expect(mockConfigManager.addStore).toHaveBeenCalledWith(
         mockAnswers.storeId,
-        mockAnswers.alias
+        mockAnswers.alias,
+        mockAnswers.projectDirectory
       );
     });
 

--- a/src/__tests__/commands/project.test.ts
+++ b/src/__tests__/commands/project.test.ts
@@ -46,7 +46,7 @@ describe('Project Commands', () => {
       const mockAnswers = {
         storeId: 'test-store',
         alias: 'test-alias',
-        projectDirectory: '/path/to/project'
+        projectDir: 'test-store-dir'
       };
       
       mockPrompt.mockResolvedValue(mockAnswers);
@@ -69,32 +69,36 @@ describe('Project Commands', () => {
         }),
         expect.objectContaining({
           type: 'input',
-          name: 'projectDirectory',
+          name: 'projectDir',
           message: 'Enter the project directory path:',
-          default: process.cwd()
         })
       ]);
       
       expect(mockConfigManager.addStore).toHaveBeenCalledWith(
         mockAnswers.storeId,
         mockAnswers.alias,
-        mockAnswers.projectDirectory
+        mockAnswers.projectDir
       );
     });
 
     it('should use store ID as alias when no alias is provided', async () => {
       // Setup
       const storeId = 'test-store';
+      const alias = 'test-alias';
+      const projectDir = 'test-store-dir';
       mockPrompt.mockResolvedValue({
-        storeId,
-        alias: storeId // Default value when user doesn't input an alias
+        storeId, alias, projectDir
       });
 
       // Execute
       await program.parseAsync(['node', 'test', 'add']);
 
       // Assert
-      expect(mockConfigManager.addStore).toHaveBeenCalledWith(storeId, storeId);
+      expect(mockConfigManager.addStore).toHaveBeenCalledWith(
+        storeId, 
+        alias,
+        projectDir
+      );
     });
 
     it('should validate required store ID', async () => {
@@ -106,6 +110,7 @@ describe('Project Commands', () => {
           message: 'Enter the Shopify store ID:',
           validate: expect.any(Function)
         },
+        expect.any(Object),
         expect.any(Object)
       ];
 
@@ -122,7 +127,8 @@ describe('Project Commands', () => {
         // Return mock answers after validation
         return {
           storeId: 'valid-store',
-          alias: 'test-alias'
+          alias: 'test-alias',
+          projectDir: 'test-store-dir'
         };
       });
 
@@ -137,7 +143,11 @@ describe('Project Commands', () => {
   describe('list command', () => {
     it('should execute shopify CLI command with correct store ID', async () => {
       // Setup
-      mockConfigManager.getStore.mockReturnValue({ storeId: 'test-store', alias: 'test-alias' });
+      mockConfigManager.getStore.mockReturnValue({ 
+        storeId: 'test-store', 
+        alias: 'test-alias',
+        projectDir: 'test-store-dir'
+      });
       (execSync as jest.Mock).mockReturnValue(Buffer.from('themes list'));
 
       // Execute
@@ -152,7 +162,11 @@ describe('Project Commands', () => {
 
     it('should include name filter when provided', async () => {
       // Setup
-      mockConfigManager.getStore.mockReturnValue({ storeId: 'test-store', alias: 'test-alias' });
+      mockConfigManager.getStore.mockReturnValue({ 
+        storeId: 'test-store', 
+        alias: 'test-alias',
+        projectDir: 'test-store-dir'
+      });
       (execSync as jest.Mock).mockReturnValue(Buffer.from('themes list'));
 
       // Execute
@@ -184,7 +198,11 @@ describe('Project Commands', () => {
   describe('dev command', () => {
     it('should start theme development server with correct parameters', async () => {
       // Setup
-      mockConfigManager.getStore.mockReturnValue({ storeId: 'test-store', alias: 'test-alias' });
+      mockConfigManager.getStore.mockReturnValue({ 
+        storeId: 'test-store', 
+        alias: 'test-alias',
+        projectDir: 'test-store-dir'
+      });
       (spawn as jest.Mock).mockReturnValue({
         on: jest.fn()
       });

--- a/src/__tests__/commands/project.test.ts
+++ b/src/__tests__/commands/project.test.ts
@@ -32,6 +32,8 @@ describe('Project Commands', () => {
       addStore: jest.fn(),
       getStore: jest.fn(),
       listStores: jest.fn(),
+      setWorkspace: jest.fn(),
+      getWorkspace: jest.fn()
     } as any;
     
     (ConfigManager as jest.Mock).mockImplementation(() => mockConfigManager);
@@ -219,6 +221,33 @@ describe('Project Commands', () => {
           shell: true
         })
       );
+    });
+  });
+
+  describe('set-workspace command', () => {
+    it('should set workspace with provided path', async () => {
+      // Setup
+      const testDir = '/test/path';
+      mockConfigManager.setWorkspace.mockImplementation(() => {});
+      mockConfigManager.getWorkspace.mockReturnValue(testDir);
+
+      // Execute
+      await program.parseAsync(['node', 'test', 'set-workspace', testDir]);
+
+      // Assert
+      expect(mockConfigManager.setWorkspace).toHaveBeenCalledWith(testDir);
+    });
+
+    it('should default to current directory when no path provided', async () => {
+      // Setup
+      mockConfigManager.setWorkspace.mockImplementation(() => {});
+      mockConfigManager.getWorkspace.mockReturnValue(process.cwd());
+
+      // Execute
+      await program.parseAsync(['node', 'test', 'set-workspace']);
+
+      // Assert
+      expect(mockConfigManager.setWorkspace).toHaveBeenCalledWith(process.cwd());
     });
   });
 }); 

--- a/src/__tests__/utils/config.test.ts
+++ b/src/__tests__/utils/config.test.ts
@@ -128,60 +128,60 @@ describe('ConfigManager', () => {
     });
   });
 
-  describe('root directory', () => {
-    it('should set root directory in config', () => {
+  describe('workspace', () => {
+    it('should set workspace in config', () => {
       // Setup
       const config = new ConfigManager();
-      const rootDir = '/path/to/root';
+      const workspace = '/path/to/workspace';
       const writeSpy = jest.spyOn(ConfigManager.prototype as any, 'saveConfig');
 
       // Execute
-      config.setRootDirectory(rootDir);
+      config.setWorkspace(workspace);
 
       // Assert
       expect(writeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          rootDirectory: rootDir,
+          workspace: workspace,
           stores: expect.any(Array)
         })
       );
     });
 
-    it('should normalize the root directory path', () => {
+    it('should normalize the directory path', () => {
       // Setup
       const config = new ConfigManager();
       const writeSpy = jest.spyOn(ConfigManager.prototype as any, 'saveConfig');
 
       // Execute
-      config.setRootDirectory('./relative/path');
+      config.setWorkspace('./relative/path');
 
       // Assert
       expect(writeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          rootDirectory: expect.stringMatching(/^\/.*\/relative\/path$/),
+          workspace: expect.stringMatching(/^\/.*\/relative\/path$/),
           stores: expect.any(Array)
         })
       );
     });
 
-    it('should get root directory from config', () => {
+    it('should get workspace from config', () => {
       // Setup
-      const rootDir = '/path/to/root';
+      const workspace = '/path/to/workspace';
       (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
         stores: [],
-        rootDirectory: rootDir
+        workspace: workspace
       }));
       
       const config = new ConfigManager();
 
       // Execute
-      const result = config.getRootDirectory();
+      const result = config.getWorkspace();
 
       // Assert
-      expect(result).toBe(rootDir);
+      expect(result).toBe(workspace);
     });
 
-    it('should return undefined if no root directory is set', () => {
+    it('should return undefined if no workspace is set', () => {
       // Setup
       (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
         stores: []
@@ -190,7 +190,7 @@ describe('ConfigManager', () => {
       const config = new ConfigManager();
 
       // Execute
-      const result = config.getRootDirectory();
+      const result = config.getWorkspace();
 
       // Assert
       expect(result).toBeUndefined();

--- a/src/__tests__/utils/config.test.ts
+++ b/src/__tests__/utils/config.test.ts
@@ -61,11 +61,11 @@ describe('ConfigManager', () => {
       const writeSpy = jest.spyOn(ConfigManager.prototype as any, 'saveConfig');
 
       // Execute
-      config.addStore('test-store-id', 'test-alias');
+      config.addStore('test-store-id', 'test-alias', 'test-store-dir');
 
       // Assert
       expect(writeSpy).toHaveBeenCalledWith({
-        stores: [{ storeId: 'test-store-id', alias: 'test-alias' }]
+        stores: [{ storeId: 'test-store-id', alias: 'test-alias', projectDir: 'test-store-dir' }]
       });
     });
   });
@@ -74,7 +74,11 @@ describe('ConfigManager', () => {
     it('should return store config when alias exists', () => {
       // Setup
       (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
-        stores: [{ storeId: 'test-store-id', alias: 'test-alias' }]
+        stores: [{ 
+          storeId: 'test-store-id', 
+          alias: 'test-alias',
+          projectDir: 'test-store-dir'
+        }]
       }));
       
       const config = new ConfigManager();
@@ -83,7 +87,11 @@ describe('ConfigManager', () => {
       const store = config.getStore('test-alias');
 
       // Assert
-      expect(store).toEqual({ storeId: 'test-store-id', alias: 'test-alias' });
+      expect(store).toEqual({ 
+        storeId: 'test-store-id', 
+        alias: 'test-alias',
+        projectDir: 'test-store-dir'
+      });
     });
 
     it('should return undefined when alias does not exist', () => {
@@ -102,8 +110,8 @@ describe('ConfigManager', () => {
     it('should return all stored configurations', () => {
       // Setup
       const mockStores = [
-        { storeId: 'store-1', alias: 'alias-1' },
-        { storeId: 'store-2', alias: 'alias-2' }
+        { storeId: 'store-1', alias: 'alias-1', projectDir: 'dir-1' },
+        { storeId: 'store-2', alias: 'alias-2', projectDir: 'dir-2' }
       ];
       
       (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({

--- a/src/__tests__/utils/config.test.ts
+++ b/src/__tests__/utils/config.test.ts
@@ -127,4 +127,74 @@ describe('ConfigManager', () => {
       expect(stores).toEqual(mockStores);
     });
   });
+
+  describe('root directory', () => {
+    it('should set root directory in config', () => {
+      // Setup
+      const config = new ConfigManager();
+      const rootDir = '/path/to/root';
+      const writeSpy = jest.spyOn(ConfigManager.prototype as any, 'saveConfig');
+
+      // Execute
+      config.setRootDirectory(rootDir);
+
+      // Assert
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootDirectory: rootDir,
+          stores: expect.any(Array)
+        })
+      );
+    });
+
+    it('should normalize the root directory path', () => {
+      // Setup
+      const config = new ConfigManager();
+      const writeSpy = jest.spyOn(ConfigManager.prototype as any, 'saveConfig');
+
+      // Execute
+      config.setRootDirectory('./relative/path');
+
+      // Assert
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootDirectory: expect.stringMatching(/^\/.*\/relative\/path$/),
+          stores: expect.any(Array)
+        })
+      );
+    });
+
+    it('should get root directory from config', () => {
+      // Setup
+      const rootDir = '/path/to/root';
+      (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
+        stores: [],
+        rootDirectory: rootDir
+      }));
+      
+      const config = new ConfigManager();
+
+      // Execute
+      const result = config.getRootDirectory();
+
+      // Assert
+      expect(result).toBe(rootDir);
+    });
+
+    it('should return undefined if no root directory is set', () => {
+      // Setup
+      (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
+        stores: []
+      }));
+      
+      const config = new ConfigManager();
+
+      // Execute
+      const result = config.getRootDirectory();
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+  });
+
 }); 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 import { ConfigManager } from '../utils/config';
 import inquirer from 'inquirer';
 import { ensureShopifyCLI } from '../utils/cli-check';
+import { join } from 'path';
+import { spawn } from 'child_process';
 
 export function setupProjectCommands(program: Command): void {
   const config = new ConfigManager();
@@ -108,5 +110,22 @@ export function setupProjectCommands(program: Command): void {
     .action(async (directory = process.cwd()) => {
       config.setWorkspace(directory);
       console.log(`Workspace set to: ${config.getWorkspace()}`);
+    });
+
+  program
+    .command('cd')
+    .description('Change to store directory')
+    .argument('<alias>', 'Store alias')
+    .action((alias) => {
+      // Execute the stm-cd script
+      const script = spawn('stm-cd', [alias], {
+        stdio: 'inherit',
+        shell: true
+      });
+
+      script.on('error', (error) => {
+        console.error('Failed to execute stm-cd:', error);
+        process.exit(1);
+      });
     });
 } 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -100,4 +100,13 @@ export function setupProjectCommands(program: Command): void {
         console.error('Error executing Shopify CLI command:', error);
       }
     });
+
+  program
+    .command('set-workspace')
+    .description('Set the workspace directory for all projects')
+    .argument('[directory]', 'Directory path (defaults to current directory)')
+    .action(async (directory = process.cwd()) => {
+      config.setWorkspace(directory);
+      console.log(`Workspace set to: ${config.getWorkspace()}`);
+    });
 } 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -26,11 +26,23 @@ export function setupProjectCommands(program: Command): void {
           type: 'input',
           name: 'alias',
           message: 'Enter an alias for the store (optional):',
-          default: (answers: { storeId: string }) => answers.storeId // Use store ID as default alias
+          default: (answers: { storeId: string }) => answers.storeId
+        },
+        {
+          type: 'input',
+          name: 'projectDirectory',
+          message: 'Enter the project directory path:',
+          default: process.cwd(),
+          validate: (input: string) => {
+            if (!input.trim()) {
+              return 'Project directory is required';
+            }
+            return true;
+          }
         }
       ]);
 
-      config.addStore(answers.storeId, answers.alias);
+      config.addStore(answers.storeId, answers.alias, answers.projectDirectory);
       console.log(`Store ${answers.alias} added successfully`);
     });
 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -30,7 +30,7 @@ export function setupProjectCommands(program: Command): void {
         },
         {
           type: 'input',
-          name: 'projectDirectory',
+          name: 'projectDir',
           message: 'Enter the project directory path:',
           default: process.cwd(),
           validate: (input: string) => {
@@ -42,7 +42,7 @@ export function setupProjectCommands(program: Command): void {
         }
       ]);
 
-      config.addStore(answers.storeId, answers.alias, answers.projectDirectory);
+      config.addStore(answers.storeId, answers.alias, answers.projectDir);
       console.log(`Store ${answers.alias} added successfully`);
     });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,7 +10,7 @@ interface StoreConfig {
 
 interface Config {
   stores: StoreConfig[];
-  rootDirectory?: string;
+  workspace?: string;
 }
 
 export class ConfigManager {
@@ -58,12 +58,12 @@ export class ConfigManager {
     return this.config.stores;
   }
 
-  setRootDirectory(directory: string): void {
-    this.config.rootDirectory = resolve(directory);
+  setWorkspace(directory: string): void {
+    this.config.workspace = resolve(directory);
     this.saveConfig(this.config);
   }
 
-  getRootDirectory(): string | undefined {
-    return this.config.rootDirectory;
+  getWorkspace(): string | undefined {
+    return this.config.workspace;
   }
 } 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 
 interface StoreConfig {
@@ -10,6 +10,7 @@ interface StoreConfig {
 
 interface Config {
   stores: StoreConfig[];
+  rootDirectory?: string;
 }
 
 export class ConfigManager {
@@ -55,5 +56,14 @@ export class ConfigManager {
 
   listStores(): StoreConfig[] {
     return this.config.stores;
+  }
+
+  setRootDirectory(directory: string): void {
+    this.config.rootDirectory = resolve(directory);
+    this.saveConfig(this.config);
+  }
+
+  getRootDirectory(): string | undefined {
+    return this.config.rootDirectory;
   }
 } 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 interface StoreConfig {
   storeId: string;
   alias: string;
+  projectDirectory: string;
 }
 
 interface Config {
@@ -42,8 +43,8 @@ export class ConfigManager {
     writeFileSync(this.configPath, JSON.stringify(config, null, 2));
   }
 
-  addStore(storeId: string, alias: string): void {
-    const store = { storeId, alias };
+  addStore(storeId: string, alias: string, projectDirectory: string): void {
+    const store = { storeId, alias, projectDirectory };
     this.config.stores.push(store);
     this.saveConfig(this.config);
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 interface StoreConfig {
   storeId: string;
   alias: string;
-  projectDirectory: string;
+  projectDir: string;
 }
 
 interface Config {
@@ -43,8 +43,8 @@ export class ConfigManager {
     writeFileSync(this.configPath, JSON.stringify(config, null, 2));
   }
 
-  addStore(storeId: string, alias: string, projectDirectory: string): void {
-    const store = { storeId, alias, projectDirectory };
+  addStore(storeId: string, alias: string, projectDir: string): void {
+    const store = { storeId, alias, projectDir };
     this.config.stores.push(store);
     this.saveConfig(this.config);
   }


### PR DESCRIPTION
# Add Directory Navigation Feature

This PR adds the ability to quickly navigate between project directories using the CLI tool.

## Changes

### New Commands

- `stm cd <alias>` - Change to a store's project directory
- `stm set-workspace` - Set the root workspace directory for all projects

### New Features

1. Workspace Management
   - Added workspace configuration to store the root directory for all projects
   - Stores can be organized under a common workspace
   - Workspace path is stored in the global config

2. Directory Navigation
   - Added shell script (`stm-cd`) to handle directory changes
   - Integrated with workspace and project directory paths
   - Error handling for missing workspace or store configurations

### Implementation Details

- Added `workspace` field to config storage
- Created shell script for directory navigation
- Added tests for new commands and configurations
- Updated documentation with new features

### Example Usage